### PR TITLE
playersocket queue; prettify exits and default page

### DIFF
--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -23,14 +23,16 @@
   text-align: center;
 }
 .section {
-  border-top: 1px solid #eee;
-  padding: 3rem 0;
+  padding: 2rem 0;
   margin-bottom: 0;
 }
 .section h2 {
   text-transform: uppercase;
   font-size: 1.4rem;
   letter-spacing: .2rem;
+}
+.section .padded .button {
+  margin-top: 2rem;
 }
 .gameView .viewport {
   position: absolute;
@@ -136,18 +138,20 @@ nav.bottom .action i {
   margin-top: .2rem;
   margin-bottom: .5rem;
 }
-li.exit {
-  list-style-type: none;
-  padding-left: 2rem;
-} 
-.exit .door {
-  font-weight: bold;
-  display: inline-block;
+.exits dt {
+  float: left;
+  clear: left;
   width: 3rem;
+  text-align: right;
+  font-weight: bold;
+  color: green;
 }
-.trophy .date,
-.chat .date {
-  float: right;
+.exits dt:after {
+  content: ":";
+}
+.exits dd {
+  margin: 0 0 0 3.5rem;
+  padding: 0 0 0.5rem 0;
 }
 .location .name:before {
   font-family: "FontAwesome";

--- a/src/public/templates/default.html
+++ b/src/public/templates/default.html
@@ -8,7 +8,7 @@
     <div class="center">
       <div>You are in a maze of little interconnected rooms, none alike.</div>
       <div>And you aren't alone.</div>
-      <div><a class="button" ui-sref="default.login">Login</a></div>
+      <div class="padded"><a class="button" ui-sref="default.login">Login</a></div>
     </div>
   </div>
   <div class="section" data-ng-switch-when="default.login">
@@ -39,22 +39,22 @@
     <form name="createProfileForm">
       <div class="row">
         <div class="one-half column">
-          <label for="username">Username</label> 
-          <input class="u-full-width" type="text" name="username" data-ng-model="user.profile.name" 
-                 required title="{{user.rules.nameRule}}" data-ng-pattern="user.rules.namePattern" /> 
+          <label for="username">Username</label>
+          <input class="u-full-width" type="text" name="username" data-ng-model="user.profile.name"
+                 required title="{{user.rules.nameRule}}" data-ng-pattern="user.rules.namePattern" />
           <a class="button u-full-width" data-ng-click="generateUsername()">Generate a username</a>
-          <div ng-show="createProfileForm.username.$error.required">&lt;?&gt; moves the chair.</div> 
+          <div ng-show="createProfileForm.username.$error.required">&lt;?&gt; moves the chair.</div>
           <div ng-hide="createProfileForm.username.$error.required">{{ createProfileForm.username.$viewValue }} moves the chair.</div>
-          <div ng-show="createProfileForm.username.$error.pattern">{{ user.rules.nameRule }}</div>&nbsp; 
+          <div ng-show="createProfileForm.username.$error.pattern">{{ user.rules.nameRule }}</div>&nbsp;
         </div>
         <div class="one-half column">
-          <label for="favColor">Favorite color</label> 
-          <input class="u-full-width" type="text" name="favoriteColor" data-ng-model="user.profile.favoriteColor" 
-                 required title="{{user.rules.colorRule}}" data-ng-pattern="user.rules.colorPattern"> 
+          <label for="favColor">Favorite color</label>
+          <input class="u-full-width" type="text" name="favoriteColor" data-ng-model="user.profile.favoriteColor"
+                 required title="{{user.rules.colorRule}}" data-ng-pattern="user.rules.colorPattern">
           <a class="button u-full-width" data-ng-click="generateColor()">Generate a color</a>
-          <div ng-show="createProfileForm.favoriteColor.$error.required">{{ createProfileForm.username.$viewValue }} loves the color &lt;?&gt;</div> 
+          <div ng-show="createProfileForm.favoriteColor.$error.required">{{ createProfileForm.username.$viewValue }} loves the color &lt;?&gt;</div>
           <div ng-hide="createProfileForm.favoriteColor.$error.required">{{ createProfileForm.username.$viewValue }} loves the color {{ createProfileForm.favoriteColor.$viewValue }}</div>
-          <div ng-show="createProfileForm.favoriteColor.$error.pattern">{{ user.rules.colorRule }}</div>&nbsp; 
+          <div ng-show="createProfileForm.favoriteColor.$error.pattern">{{ user.rules.colorRule }}</div>&nbsp;
         </div>
       </div>
       <div class="section center">
@@ -65,13 +65,17 @@
     </form>
   </div>
   <div class="section" data-ng-switch-default>
-    <div class="section">
+    <div class="center">
         <div>Something went wrong...</div>
     </div>
   </div>
+  <div class="section">
+    <div class="center">
+      <div><a href="http://game-on.org">All about Game On!</a></div>
+    </div>
+  </div>
 </div>
-<footer class="footer section container">
+<footer class="footer section">
   <div title="peace, love, play"><i class="fa fa-hand-peace-o"></i> <i class="fa fa-heart-o"></i> <i class="fa fa-play"></i></div>
-    the <a href="http://wasdev.net" target="_blank">wasdev</a> team<br />
-    <a href="http://game-on.org">info site</a>
+  <div>the <a href="http://wasdev.net" target="_blank">wasdev</a> team</div>
 </footer>

--- a/src/public/templates/play.room.html
+++ b/src/public/templates/play.room.html
@@ -11,16 +11,17 @@
         <div data-ng-switch-when="command" class="command"><div class="content">{{data.content}}</div></div>
         <div data-ng-switch-when="exit"><div ng-bind-html="data.content" class="content">{{data.content}}</div></div>
         <div data-ng-switch-when="location" class="location"><div class="name"> &nbsp;{{data.name}}</div>
-             <div ng-bind-html="data.description" class="description">{{data.description}}</div>
-             <div ng-bind-html="data.content" class="content">{{data.content}}</div>
-             <div data-ng-if="data.objects" class="objects">You notice: <ul ng-repeat="object in data.objects"><li ng-bind-html="object">{{ object }}</li></ul></div>
+          <div ng-bind-html="data.description" class="description">{{data.description}}</div>
+          <div ng-bind-html="data.content" class="content">{{data.content}}</div>
+          <div data-ng-if="data.objects.length" class="objects">You notice: <ul><li ng-repeat="object in data.objects" ng-bind-html="object">{{ object }}</li></ul></div>
         </div>
-        <div data-ng-switch-when="exits"><div data-ng-if="data.content" class="objects">You notice: 
-              <ul ng-repeat="(key, value) in data.content" ng-bind-html="value" ><li class="exit"><span class="door" >{{ key }}</span> {{ value }}</li></ul></div></div>
+        <div data-ng-switch-when="exits"><div data-ng-if="data.content">You can get out the following ways:
+          <dl class="exits"><dt class="door" ng-repeat-start="(key, value) in data.content"><a title="/go {{key}}" ng-click="sendFixed('/go ' + key)">{{ key }}</a></dt><dd ng-repeat-end>{{value}}</dd></dl>
+        </div></div>
         <div data-ng-switch-default>{{ data }}</div>
       </div>
     </div>
-  </div>    
+  </div>
 </div>
 <nav class="top">
   <div class="action"><a ng-click="sendFixed('/me')"><i class="fa fa-user"></i></a></div>


### PR DESCRIPTION
* Queue messages while websocket is closed/reconnecting
* Change some spacing/alingment on the default pages.
* Change display of /exits to use a definition list, with a clickable link for the direction, followed by the description.