### PR TITLE
Local caching for exits, no /exits command sent to the server

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -76,6 +76,7 @@
         <script src="scripts/controllers/play.js"></script>
         <script src="scripts/directives/profileCore.js"></script>
         <script src="scripts/services/playerSocket.js"></script>
+        <script src="scripts/services/playerSession.js"></script>
         <script src="scripts/services/auth.js"></script>
         <script src="scripts/services/user.js"></script>
         <!-- endbuild -->

--- a/src/public/scripts/app.js
+++ b/src/public/scripts/app.js
@@ -29,7 +29,7 @@ angular.module('playerApp', ['ngResource','ngSanitize','ui.router','ngWebSocket'
   ])
   .constant("API", {
     "PROFILE_URL": "https://"+baseUrl+"/play/players/",
-    "WS_URL": "wss://"+baseUrl+"/play/ws1/",
+    "WS_URL": "wss://"+baseUrl+"/mediator/ws/",
     "CERT_URL": "https://"+baseUrl+"/play/PublicCertificate",
     "DUMMYGOOGLE": "https://"+baseUrl+"/play/DummyAuth?dummyUserName=AnonymousGoogleUser",
     "DUMMYLINKEDIN": "https://"+baseUrl+"/play/DummyAuth?dummyUserName=AnonymousLinkedinUser",
@@ -37,16 +37,16 @@ angular.module('playerApp', ['ngResource','ngSanitize','ui.router','ngWebSocket'
     "FACEBOOK": "https://"+baseUrl+"/play/FacebookAuth",
   })
   .config(
-  [          '$stateProvider','$urlRouterProvider', 
+  [          '$stateProvider','$urlRouterProvider',
     function ($stateProvider,  $urlRouterProvider) {
-    
+
       // Use $urlRouterProvider to configure any redirects (when) and invalid urls (otherwise).
       // The `when` method says if the url is ever the 1st param, then redirect to the 2nd param
       $urlRouterProvider
         .otherwise('/');
-          
+
       //////////////////////////
-      // State Configurations 
+      // State Configurations
 
       $stateProvider
         .state('default', {
@@ -58,10 +58,10 @@ angular.module('playerApp', ['ngResource','ngSanitize','ui.router','ngWebSocket'
             url: '^/login',
         })
         .state('default.auth', {
-          url: '^/login/callback/{jwt:.*}',        
-		  // State triggered by authentication callback (only). 
+          url: '^/login/callback/{jwt:.*}',
+		  // State triggered by authentication callback (only).
           onEnter: function($state, $stateParams,auth) {
-           		console.log("default.auth.onEnter");          
+           		console.log("default.auth.onEnter");
 				auth.get_public_key(
 				function(){
 				    console.log("got public cert.. proceeding to jwt validation.");
@@ -73,7 +73,7 @@ angular.module('playerApp', ['ngResource','ngSanitize','ui.router','ngWebSocket'
 					//TODO: handle failure to obtain public key.
 					//      can't do much without it.
 					$state.go('default.yuk');
-				});          		
+				});
            }
         })
         .state('default.validatejwt', {
@@ -84,36 +84,36 @@ angular.module('playerApp', ['ngResource','ngSanitize','ui.router','ngWebSocket'
             // and cause it to be stashed into the auth object so we can rely on it going forwards.
 
             console.log("default.validatejwt.onEnter");
-            if(auth.validate_jwt()){            
+            if(auth.validate_jwt()){
                 console.log("token callback from auth service was valid");
                 $state.go('default.usersetup');
             }else{
-                //TODO: goto a login failed page.. 
+                //TODO: goto a login failed page..
                 $state.go('default.login');
             }
           }
         })
-        .state('default.usersetup', { 
+        .state('default.usersetup', {
           url: '^/login/usersetup',
-          // Triggered by default.auth state. 
+          // Triggered by default.auth state.
           onEnter: function($state, $stateParams,auth,user) {
             console.log("building user object");
             var jwt = auth.get_jwt();
-            if(jwt!=null){
-                // Verify the returned token... 
+            if (jwt !== null){
+                // Verify the returned token...
                 console.log("cached/recovered token was valid, token info object was");
                 console.log(jwt);
-                //user.load returns a promise that resolves to true if the user was found.. false otherwise. 
+                //user.load returns a promise that resolves to true if the user was found.. false otherwise.
                 user.load(jwt.id, jwt.name).then(function(userKnownToDB){
                   if(userKnownToDB){
                     $state.go('play.room');
                   }else{
-                    $state.go('default.profile');  
+                    $state.go('default.profile');
                   }
                 });
               }else{
-                //cached / recovered token was invalid. 
-                //TODO: goto a login failed page.. 
+                //cached / recovered token was invalid.
+                //TODO: goto a login failed page..
                 $state.go('default.login');
               }
           }

--- a/src/public/scripts/controllers/play.js
+++ b/src/public/scripts/controllers/play.js
@@ -19,7 +19,7 @@ angular.module('playerApp')
       this.user = user;
       this.userInput = '';
       this.roomEvents = playerSocket.roomEvents;
-      this.playerSession = playerSocket.playerSession;
+      this.clientState = playerSocket.clientState;
       this.fixKeyboard = "";
 
       this.restart = function() {
@@ -79,6 +79,10 @@ angular.module('playerApp')
         this.userInput = input;
         inputBox.focus();
       };
+
+      this.listExits = function() {
+        playerSocket.listExits();
+      }
 
       this.send = function() {
         var input = this.userInput;

--- a/src/public/scripts/services/auth.js
+++ b/src/public/scripts/services/auth.js
@@ -11,25 +11,25 @@
  */
 angular.module('playerApp')
   .factory('auth',
-  [          '$log','API','$http',
-    function ($log,  API,  $http) {
+  [          '$log','API','$http','playerSession',
+    function ($log,  API,  $http,  playerSession) {
 	    console.log("Loading AUTH");
 
-	    var _token = null,            
+	    var _token = null,
         	_publicKey = null,
-            _authenticated = null; 
+            _authenticated = null;
 
         function get_public_key(success,failure){
         	$log.debug('Requesting public cert to validate jwts with');
       		if(_publicKey === null){
-      			var q = $http({
+      			$http({
                     method : 'GET',
                     url : API.CERT_URL,
                     cache : false
                 }).then(function (data) {
                 	 $log.debug('Obtained certificate', data.data);
 			        _publicKey = data.data;
-			        localStorage.publicKey = _publicKey;
+			        playerSession.set('publicKey', _publicKey);
 			        success();
 			    }, failure);
       		}else{
@@ -38,29 +38,29 @@ angular.module('playerApp')
       			success();
       		}
         }
-        
+
         function remember_jwt(jwt){
         	_token = jwt;
         }
-        
+
         /**
          * Verify if the jwt is still valid.
          */
         function validate_jwt() {
           $log.debug('Validating jwt');
-          delete localStorage.token;
+          playerSession.remove('token');
           $log.debug("old token flushed");
-          
+
           if(typeof _token === 'undefined'){
         	  $log.debug("token validation failed, null token");
         	  return false;
           }
-          
-          var pubkey = KEYUTIL.getKey(_publicKey);          
+
+          var pubkey = KEYUTIL.getKey(_publicKey);
           var isValid = KJUR.jws.JWS.verifyJWT(_token,pubkey,{alg: ['RS256'] });
-          
+
           if(isValid){
-	          localStorage.token = angular.toJson(_token);	          	          
+	          playerSession.set('token', _token);
 	          $log.debug("token validation passed");
 	          _authenticated = Promise.resolve(true);
 	          return true;
@@ -69,11 +69,11 @@ angular.module('playerApp')
 	          _authenticated = Promise.resolve(false);
 	          return false;
           }
-        }               
+        }
 
         function logout() {
           _authenticated = Promise.resolve(false);
-          delete localStorage.token;
+          playerSession.reset();
         }
 
 
@@ -81,30 +81,30 @@ angular.module('playerApp')
             getAuthenticationState: function () {
                 $log.debug('isAuthenticated: %o %o', this, _authenticated);
                 if (_authenticated !== null) {
-                    $log.debug('user already authenticated %o %o',_authenticated,_token);
+                    $log.debug('user already authenticated %o %o', _authenticated, _token);
                 } else {
-                    $log.debug('attempting to restore jwt from localstorage: found: %o  and %o',localStorage.token,localStorage.publicKey);
-                    _token = angular.fromJson(localStorage.token);
-                    _publicKey = localStorage.publicKey;
-                    $log.debug('jwt (hopefully) restored, validating...');
-                    _authenticated = Promise.resolve(this.validate_jwt());
+                  _token = playerSession.get('token');
+                  _publicKey = playerSession.get('publicKey');
+                  $log.debug('attempting to restore jwt from local storage: found: %o  and %o', _token, _publicKey);
+                  $log.debug('jwt (hopefully) restored, validating...');
+                  _authenticated = Promise.resolve(this.validate_jwt());
                 }
                 return _authenticated;
-            },            
+            },
             remember_jwt: remember_jwt,
-            validate_jwt: validate_jwt,   
+            validate_jwt: validate_jwt,
             get_jwt: function () {
             	$log.debug("Obtaining JWT payload, performing revalidation of jwt first");
             	if(validate_jwt()){
             		var result=0;
-            		try{    
+            		try{
             			var jws = new KJUR.jws.JWS();
             			result = jws.parseJWS(_token);
             			return angular.fromJson(jws.parsedJWS.payloadS);
             		} catch (ex) {
             			$log.error("Error parsing JWS %o ",ex);
             			return null;
-            		}            		
+            		}
             	}else{
             		return null;
             	}

--- a/src/public/scripts/services/playerSession.js
+++ b/src/public/scripts/services/playerSession.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Cache and retrieve information from local storage in the device.
+ *
+ * @ngdoc service
+ * @name playerApp.playerSession
+ * @description
+ * # playerSocket
+ * Factory in the playerApp.
+ */
+angular.module('playerApp')
+  .factory('playerSession',
+  [          '$log',
+    function ($log) {
+
+      // Read in what was stashed in local storage
+      var elements = angular.extend({}, angular.fromJson(localStorage.playerSession));
+      $log.debug("Retrieved local storage %o", elements);
+
+      var get = function(key) {
+        return elements[key];
+      };
+
+      var set = function(key, value) {
+        elements[key] = value;
+        save();
+      };
+
+      var remove = function(key) {
+        delete elements[key];
+      };
+
+      var reset = function() {
+        // Clear local storage entirely
+        elements = {};
+        delete localStorage.playerSession;
+      };
+
+      var save = function() {
+        $log.debug("Update local storage %o", elements);
+        localStorage.playerSession = angular.toJson(elements);
+      };
+
+      // Available methods and structures
+      var sharedApi = {
+        get: get,
+        set: set,
+        remove: remove,
+        reset: reset,
+        save: save
+      };
+
+      return sharedApi;
+    }
+  ]);

--- a/src/public/scripts/services/user.js
+++ b/src/public/scripts/services/user.js
@@ -13,7 +13,7 @@
 angular.module('playerApp')
   .factory('user',
   [          '$log','$state','API','$http','auth',
-    function ($log,  $state,  API,  $http, auth) {
+    function ($log,  $state,  API,  $http,  auth) {
 
     var generatedNames = [];
     var generatedColors = [];
@@ -27,7 +27,7 @@ angular.module('playerApp')
     rules.colorPattern = /^\w{3,}$/;
 
     var load = function(id,name) {
-      $log.debug('quering token %o',localStorage.token);
+      $log.debug('quering token %o',auth.token());
 
       //we're using the id from the token introspect as our player db id.
       profile.id = id;
@@ -36,7 +36,7 @@ angular.module('playerApp')
       // Load needs to come from the Auth token
       var parameters = {};
       var q;
-      
+
       parameters.jwt = auth.token();
 
       // Fetch data about the user
@@ -72,7 +72,7 @@ angular.module('playerApp')
       // the next state if all data could validate properly.
       var parameters = {};
       parameters.jwt = auth.token();
-      
+
       $http({
         method : 'POST',
         url : API.PROFILE_URL,
@@ -95,8 +95,8 @@ angular.module('playerApp')
         $log.debug("Updating user with: %o", profile);
       // Update user
       var parameters = {};
-      parameters.jwt = auth.token();  
-        
+      parameters.jwt = auth.token();
+
       $http({
         method : 'PUT',
         url : API.PROFILE_URL + profile.id,
@@ -118,7 +118,7 @@ angular.module('playerApp')
       $log.debug('generate a name: %o', generatedNames);
       var name = generatedNames.pop();
       var parameters = {};
-      parameters.jwt = auth.token(); 
+      parameters.jwt = auth.token();
       if (typeof name === 'undefined') {
         // no generated names (all used up). Let's grab some more.
         $http({
@@ -137,7 +137,7 @@ angular.module('playerApp')
           $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
 
           //fallback name generation.
-		
+
 			var size = ['Tiny','Small','Large','Gigantic','Enormous'];
 			var composition = ['Chocolate','Fruit','GlutenFree','Sticky'];
 			var extra = ['Iced','Frosted','CreamFilled','JamFilled','MapleSyrupSoaked','SprinkleCovered'];
@@ -163,8 +163,8 @@ angular.module('playerApp')
 				case 5:
 					name = composition[Math.floor((Math.random() * composition.length))]+form[Math.floor((Math.random() * form.length))];
 					break;
-			}   
-			
+			}
+
           profile.name = name;
         }).catch(console.log.bind(console));
       } else {
@@ -179,7 +179,7 @@ angular.module('playerApp')
       if (typeof color === 'undefined') {
         // no generated colors (all used up). Let's grab some more.
         var parameters = {};
-        parameters.jwt = auth.token();     	  
+        parameters.jwt = auth.token();
         $http({
           method : 'GET',
           url : API.PROFILE_URL + 'colors',

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -67,7 +67,6 @@ header {
   width: 100%;
   height: 4rem;
   padding: .3rem .5rem;
-  vertical-align: middle;
 }
 nav {
   background-color: #3c3232;
@@ -99,7 +98,6 @@ nav .clear {
   top: .7rem;
   right: 3.6rem;
   padding: 0 .6rem;
-  z-index: 100;
 }
 nav .clear a {
     color: #aaa;
@@ -220,20 +218,20 @@ div.exits:before {
 .location .objects ul>li {
   margin: 0;
 }
-.event:after, nav.top:after, nav:after {
+.event:after, .top:after, nav:after {
   content: "";
   display: table;
   clear: both;
 }
 
-@media ( min-width : 325px) {
+@media (min-width : 325px) {
   .intro {
     width: 22rem;
   }
 }
 
 /* Larger than phablet */
-@media ( min-width : 550px) {
+@media (min-width : 550px) {
   .header {
     margin-top: 18rem;
   }

--- a/src/public/templates/play.room.html
+++ b/src/public/templates/play.room.html
@@ -1,16 +1,16 @@
 <header>
   <div class="action"><a ui-sref="play.me"><i class="fa fa-user fa-fw"></i></a></div>
   <div class="action"><a ng-click="play.sendFixed('/help')"><i class="fa fa-life-ring fa-fw"></i></a></div>
-  <div class="action"><a ng-click="play.sendFixed('/exits')"><i class="fa fa-map-signs fa-fw"></i></a></div>
+  <div class="action"><a ng-click="play.listExits()"><i class="fa fa-map-signs fa-fw"></i></a></div>
   <div class="action"><a ng-click="play.sendFixed('/inventory')"><i class="fa fa-suitcase fa-fw"></i></a></div>
   <div class="action"><a ng-click="play.fillin('/examine ')"><i class="fa fa-eye fa-fw"></i></a></div>
-  <div class="title"><a ng-click="play.sendFixed('/look')"><i class="fa fa-cube fa-fw"></i> {{ play.playerSession.roomId }}</a></div>
+  <div class="title"><a ng-click="play.sendFixed('/look')"><i class="fa fa-cube fa-fw"></i> {{ play.clientState.roomId }}</a></div>
 </header>
 <div class="viewport" scroll-glue>
   <div class="container">
     <div>
       <div ng-repeat="data in play.roomEvents track by data.id" data-ng-switch="data.type">
-        <div data-ng-switch-when="chat" class="element chat" ng-class="{ 'me': data.username == play.playerSession.username}">
+        <div data-ng-switch-when="chat" class="element chat" ng-class="{ 'me': data.username == play.clientState.username}">
             <div class="username">{{data.username}}</div>
             <div class="content">{{data.content}}</div>
         </div>
@@ -21,8 +21,8 @@
         <div data-ng-switch-when="location" class="element location"><div class="name">{{data.name}}</div>
           <div ng-bind-html="data.description" class="description"></div>
           <div ng-bind-html="data.content" class="content"></div>
-          <div data-ng-if="data.objects.length" class="objects">You notice:
-              <ul><li ng-repeat="object in data.objects"><a ng-click="play.append(object)">{{ object }}</a></li></ul>
+          <div data-ng-if="data.roomInventory.length" class="objects">You notice:
+              <ul><li ng-repeat="object in data.roomInventory"><a ng-click="play.append(object)">{{ object }}</a></li></ul>
           </div>
         </div>
         <div data-ng-switch-when="exits" data-ng-if="data.content" class="element exits">Visible exits:


### PR DESCRIPTION
Pull out the storage to localSession into its own class (clean up individual local session management)

Break out clientState (room and bookmark, things sent on many requests) from gameData (cached exits and room inventory).

Did not change inventory display to include the distinction between the player and the room.