### PR TITLE
Send JWT via HTTP headers and via ws connect

### DIFF
--- a/src/public/scripts/services/playerSocket.js
+++ b/src/public/scripts/services/playerSocket.js
@@ -20,7 +20,7 @@ angular.module('playerApp')
     function ($websocket,  $log,  user,  auth,  API,  playerSession, marked) {
 
       var ws;
-      var websocketURL = API.WS_URL + user.profile._id + "?jwt="+auth.token();
+      var websocketURL = API.WS_URL + user.profile._id;
       var id = 0;
 
       // Collection for holding data: play.room.html displays
@@ -47,6 +47,7 @@ angular.module('playerApp')
         clientState.roomId = user.profile.location;
       }
       clientState.username = user.profile.name;
+      clientState.jwt = auth.token();
 
       // Create a v1 websocket
       $log.debug("Opening player socket %o for %o",websocketURL, user.profile);

--- a/src/public/scripts/services/user.js
+++ b/src/public/scripts/services/user.js
@@ -34,17 +34,15 @@ angular.module('playerApp')
 
       // Load the user's information from the DB and/or session
       // Load needs to come from the Auth token
-      var parameters = {};
+      var gameonHeaders = {'gameon-jwt': auth.token()};
       var q;
-
-      parameters.jwt = auth.token();
 
       // Fetch data about the user
       q = $http({
         method : 'GET',
         url : API.PROFILE_URL + profile._id,
         cache : false,
-        params : parameters
+        headers : gameonHeaders
       }).then(function(response) {
         $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
 
@@ -70,15 +68,14 @@ angular.module('playerApp')
       $log.debug("Creating user with: %o", profile);
       // CREATE -- needs to test for ID uniqueness.. so only go on to
       // the next state if all data could validate properly.
-      var parameters = {};
-      parameters.jwt = auth.token();
+      var gameonHeaders = {'gameon-jwt': auth.token()};
 
       $http({
         method : 'POST',
         url : API.PROFILE_URL,
         cache : false,
         data : profile,
-        params : parameters
+        headers : gameonHeaders
       }).then(function(response) {
         $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
         $state.go('play.room');
@@ -94,15 +91,14 @@ angular.module('playerApp')
     var update = function() {
         $log.debug("Updating user with: %o", profile);
       // Update user
-      var parameters = {};
-      parameters.jwt = auth.token();
+      var gameonHeaders = {'gameon-jwt': auth.token()};
 
       $http({
         method : 'PUT',
         url : API.PROFILE_URL + profile._id,
         cache : false,
         data : profile,
-        params : parameters
+        headers : gameonHeaders
       }).then(function(response) {
         $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
         $state.go('play.room');
@@ -117,8 +113,7 @@ angular.module('playerApp')
     var updateApiKey = function() {
         $log.debug("Updating user apikey for profile : %o", profile);
       // Update user
-      var parameters = {};
-      parameters.jwt = auth.token();
+      var gameonHeaders = {'gameon-jwt': auth.token()};
       
       delete profile.apiKey;
 
@@ -127,7 +122,7 @@ angular.module('playerApp')
         url : API.PROFILE_URL + profile._id,
         cache : false,
         data : profile,
-        params : parameters
+        headers : gameonHeaders
       }).then(function(response) {
         $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
         //update succeeded, now refresh the profile from the server to pull the new key.
@@ -143,15 +138,15 @@ angular.module('playerApp')
     var generateName = function() {
       $log.debug('generate a name: %o', generatedNames);
       var name = generatedNames.pop();
-      var parameters = {};
-      parameters.jwt = auth.token();
+      var gameonHeaders = {'gameon-jwt': auth.token()};
+      
       if (typeof name === 'undefined') {
         // no generated names (all used up). Let's grab some more.
         $http({
           method : 'GET',
           url : API.PROFILE_URL + 'names',
           cache : false,
-          params : parameters
+          headers : gameonHeaders
         }).then(function(response) {
           $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
 
@@ -204,13 +199,12 @@ angular.module('playerApp')
 
       if (typeof color === 'undefined') {
         // no generated colors (all used up). Let's grab some more.
-        var parameters = {};
-        parameters.jwt = auth.token();
+    	var gameonHeaders = {'gameon-jwt': auth.token()};
         $http({
           method : 'GET',
           url : API.PROFILE_URL + 'colors',
           cache : false,
-          params : parameters
+          headers : gameonHeaders
         }).then(function(response) {
           $log.debug(response.status + ' ' + response.statusText + ' ' + response.data);
 


### PR DESCRIPTION
This PR cannot be done in isolation, it needs the corresponding requests in map, player and mediator which are for the move_jwt_to_headers branch.

This request externalises the JWT (so that it can be shared/consistent) and moves any use of the jwt query param to a gameon-jwt HTTP header. It also adds the JWT to the websocket initialisation for the mediator to validate.