### PR TITLE
Websocket in JavaScript doesn't support headers, keep in queryString

### DIFF
--- a/src/public/scripts/services/playerSocket.js
+++ b/src/public/scripts/services/playerSocket.js
@@ -20,8 +20,11 @@ angular.module('playerApp')
     function ($websocket,  $log,  user,  auth,  API,  playerSession, marked) {
 
       var ws;
-      var websocketURL = API.WS_URL + user.profile._id;
       var id = 0;
+
+      // There is no way to add additional HTTP headers to the outbound
+      // WebSocket -- the token needs to remain in the query string.
+      var websocketURL = API.WS_URL + user.profile._id  + "?jwt=" + auth.token();
 
       // Collection for holding data: play.room.html displays
       // this scrolling collection.
@@ -47,7 +50,6 @@ angular.module('playerApp')
         clientState.roomId = user.profile.location;
       }
       clientState.username = user.profile.name;
-      clientState.jwt = auth.token();
 
       // Create a v1 websocket
       $log.debug("Opening player socket %o for %o",websocketURL, user.profile);

--- a/src/public/scripts/services/playerSocket.js
+++ b/src/public/scripts/services/playerSocket.js
@@ -93,6 +93,10 @@ angular.module('playerApp')
             $log.debug('commands updated', gameData);
           }
 
+          // Update saved session data
+          playerSession.set('clientState', clientState);
+          playerSession.set('gameData', gameData);
+
           if ( !canSend ) {
             // indicate we can send again, and catch up with anything
             // we queued while the connection was re-establishing itself
@@ -130,6 +134,8 @@ angular.module('playerApp')
             gameData.roomInventory = res.roomInventory;
             $log.debug('room inventory updated', gameData);
           }
+
+          playerSession.set('gameData', gameData);
 
           switch (res.type) {
             case 'event':


### PR DESCRIPTION
WebSocket support in browsers doesn't support adding arbitrary headers. We want to start verifying the JWT when the socket is opened, rather than waiting for the ready message, which means putting it back on the query parameter.