### PR TITLE
Signed-off-by: Ozzy Osborne <ozzy@ca.ibm.com>

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -37,6 +37,13 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
     nginx -c /etc/nginx/nginx-nolog.conf
   fi
 else
+  echo -n "Checking if bower has run yet.. "
+  if [ ! -d /opt/www/public/bower_components ]; then
+    echo "..bower has not run, running bower" 
+    cd /opt/www ; npm install -g bower@1.5.3 ; bower install --allow-root
+  else
+    echo "..bower has run."
+  fi 
   echo No logging host set. Running nginx to standard out...
   nginx -c /etc/nginx/nginx-nolog.conf
 fi


### PR DESCRIPTION
Using "npm install -g" here, because normally we'd install bower into the webapp subfolder, but in the only situation where we need this (local live development) that subfolder is a docker-compose mapped filesystem that itself is also mapped back from the vagrant vm back to the host.. which at least on windows seems to mean that bower is unable to install there.. so, since webapp is a vm anyways, we might as well allow it to install bower globally, and then use it from there.. that way bower is installed to parts of the docker vm filesystem that are not mapped out to the host etc.. 
It would seem once bower is installed, it has no problem creating its bower_components folder on the double mapped filesystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-webapp/61)
<!-- Reviewable:end -->
