### PR TITLE
Fix initial white screen

### DIFF
--- a/src/public/scripts/services/playerSocket.js
+++ b/src/public/scripts/services/playerSocket.js
@@ -45,7 +45,7 @@ angular.module('playerApp')
       var gameData = angular.extend({}, playerSession.get('gameData'));
 
       // Clear the bookmark if the DB says we're in a different room than the local session does.
-      if ( user.profile.location.location !== clientState.roomId ) {
+      if ( user.profile.hasOwnProperty('location') && user.profile.location.location !== clientState.roomId ) {
         $log.debug('cache cleared');
         gameData = {}; // start over
         clientState.fullName = "Unknown";


### PR DESCRIPTION
When the user profile is first created, there is no location subobject to query.
Signed-off-by: Ozzy <ozzy@ca.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-webapp/63)
<!-- Reviewable:end -->
