### PR TITLE
Better visual for blockquotes in events

### DIFF
--- a/src/public/styles/gameon.css
+++ b/src/public/styles/gameon.css
@@ -340,6 +340,17 @@ div.exits:before {
   padding-right: 1em;
 }
 
+.description blockquote,
+.event blockquote {
+  border: 1px solid silver;
+  padding: 10px;
+}
+
+.description blockquote p,
+.event blockquote p {
+  margin-bottom: 2px;
+}
+
 .key a {
   color: #EA6F56;
 }


### PR DESCRIPTION
Fixes gameontext/gameon#76

Clear rendering of blockquotes (to emulate/separate notes or other quoted text)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-webapp/82)
<!-- Reviewable:end -->
