### PR TITLE
Add connection type of websocket if missing

### DIFF
--- a/src/public/scripts/services/map.js
+++ b/src/public/scripts/services/map.js
@@ -48,6 +48,9 @@ angular.module('playerApp')
 
   var createSiteForUser = function(newSite) {
     $log.debug("MAP : CREATE : %o", newSite);
+    if(newSite.info.connectionDetails && !newSite.info.connectionDetails.type) {
+      newSite.info.connectionDetails.type = 'websocket';
+    }
     var body = angular.toJson(newSite.info);
 
     var q = $q.defer();
@@ -102,6 +105,9 @@ angular.module('playerApp')
 
   var updateSiteForUser = function(newSite) {
     $log.debug("MAP : UPDATE : %o", newSite);
+    if(newSite.info.connectionDetails && !newSite.info.connectionDetails.type) {
+      newSite.info.connectionDetails.type = 'websocket';
+    }
     var body = angular.toJson(newSite.info);
 
     var q = $q.defer();


### PR DESCRIPTION
When creating or updating a room, if the connectionDetails are present, then the type is set to web socket.
Signed off by : Adam Pilkington apilkington@uk.ibm.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-webapp/88)
<!-- Reviewable:end -->
