### PR TITLE
Ensure files are not created as root

### DIFF
--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,9 @@
 FROM node:7.5
 MAINTAINER Erin Schnabel <schnabel@us.ibm.com> (@ebullientworks)
 
+ARG userId=1000
+ARG groupId=1000
+
 ENV DEBIAN_FRONTEND noninteractive
 ENV PHANTOMJS_VERSION 2.1.1
 
@@ -17,11 +20,9 @@ RUN mkdir /tmp/phantomjs \
          | tar -xj --strip-components=1 -C /tmp/phantomjs \
   && cd /tmp/phantomjs \
   && mv bin/phantomjs /usr/local/bin \
-  && npm install -g gulp \
-  && mkdir /app \
-  && touch /root/.bashrc \
-  && mkdir /root/lib \
-  && echo "/usr/local/bin/docker-build.sh" >> /root/.bashrc
+  && echo 'export PATH=$PATH:/app/node_modules/.bin' >> /etc/bash.bashrc \
+  && mkdir -p /app/node_modules \
+  && chown -R ${userId}:${groupId} /app
 
 WORKDIR /app
 
@@ -34,4 +35,4 @@ EXPOSE 3000
 #Grunt watch
 EXPOSE 35729
 
-CMD [ "echo", "To reach a shell for building, use\n docker run --rm -it -v $PWD/app:/app -v /app/node_modules webapp-build /bin/bash" ]
+CMD [ "echo", "To reach a shell for building, use ./build.sh shell" ]

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+PATH=$PATH:/app/node_modules/.bin
 
 # Used when building inside a Docker image!
 if [ ! -f /app/gulpfile.babel.js ]; then
@@ -6,7 +7,7 @@ if [ ! -f /app/gulpfile.babel.js ]; then
 else
     cd /app
 
-echo $1
+    echo $1
     if [ $# -lt 1 ]
     then
       ACTION=default


### PR DESCRIPTION
node_modules was being created/owned by the root user, which made cleaning up between vagrant/not-vagrant/direct build /build.sh build kind of a mess. This uses current user's UID/GID, and makes sure that dirs are created before invocation to preserve ownership.

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-webapp/126)
<!-- Reviewable:end -->
