### PR TITLE
Allow non root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM nginx:stable-alpine
 
 LABEL maintainer="Erin Schnabel <schnabel@us.ibm.com> (@ebullientworks)"
 
+# support running as arbitrary user which belogs to the root group
+RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx
 COPY docker/nginx.conf        /etc/nginx/nginx.conf
 COPY docker/startup.sh        /opt/startup.sh
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5061,9 +5061,9 @@
       },
       "dependencies": {
         "gulp-cli": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
-          "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+          "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
           "dev": true,
           "requires": {
             "ansi-colors": "^1.0.1",
@@ -5074,7 +5074,7 @@
             "copy-props": "^2.0.1",
             "fancy-log": "^1.3.2",
             "gulplog": "^1.0.0",
-            "interpret": "^1.1.0",
+            "interpret": "^1.4.0",
             "isobject": "^3.0.1",
             "liftoff": "^3.1.0",
             "matchdep": "^2.0.0",
@@ -5082,14 +5082,14 @@
             "pretty-hrtime": "^1.0.0",
             "replace-homedir": "^1.0.0",
             "semver-greatest-satisfied-range": "^1.1.0",
-            "v8flags": "^3.0.1",
+            "v8flags": "^3.2.0",
             "yargs": "^7.1.0"
           }
         },
         "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
           "dev": true,
           "requires": {
             "camelcase": "^3.0.0",
@@ -5104,16 +5104,17 @@
             "string-width": "^1.0.2",
             "which-module": "^1.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "yargs-parser": "5.0.0-security.0"
           }
         },
         "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "version": "5.0.0-security.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0"
+            "camelcase": "^3.0.0",
+            "object.assign": "^4.1.0"
           }
         }
       }
@@ -6861,9 +6862,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
     "invariant": {
@@ -14491,9 +14492,9 @@
       "dev": true
     },
     "v8flags": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
-      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+      "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -20,7 +20,7 @@ else
     fi
 
     if [ "$ACTION" == "cert" ] ||  [ ! -f /app/.test-localhost-cert.pem ]; then
-      openssl req
+      openssl req \
         -newkey rsa:2048 -x509 -nodes -keyout /app/.test-localhost-keytmp.pem \
         -new -out /app/.test-localhost-cert.pem \
         -subj /CN=localhost -reqexts SAN -extensions SAN \
@@ -35,5 +35,5 @@ else
     fi
 
     npm install
-    gulp ${ACTION}
+    npx gulp ${ACTION}
 fi

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 worker_processes  1;
 daemon off;
 
@@ -55,7 +54,8 @@ http {
 
     location /health {
       access_log  off;
-      error_log   off;
+      #https://chirale.org/2018/08/01/nginx-emerg-open-usr-share-nginx-off-failed-13-permission-denied-solved/
+      #error_log off;
       return 200  'ok';
     }
   }

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+echo "using /tmp for config"
+cp /etc/nginx/nginx.conf /tmp/nginx.conf
+
 if [ "${GAMEON_MODE}" == "development" ]
 then
   if ! grep -q -r angular /opt/www/public
@@ -9,17 +12,18 @@ then
   fi
 
   # turn off sendfile for local development
-  sed -i -e "s/sendfile: .*$/sendfile: off/" /etc/nginx/nginx.conf
+  sed -i -e "s/sendfile: .*$/sendfile: off/" /tmp/nginx.conf
 else
   # turn on sendfile
-  sed -i -e "s/sendfile: .*$/sendfile: on/" /etc/nginx/nginx.conf
+  sed -i -e "s/sendfile: .*$/sendfile: on/" /tmp/nginx.conf
 fi
 
 if [ "${GAMEON_LOG_FORMAT}" == "json" ]
 then
-  sed -i -e "s/access\.log .*$/access.log json_combined;/" /etc/nginx/nginx.conf
+  sed -i -e "s/access\.log .*$/access.log json_combined;/" /tmp/nginx.conf
 else
-  sed -i -e "s/access\.log .*$/access.log combined;/" /etc/nginx/nginx.conf
+  sed -i -e "s/access\.log .*$/access.log combined;/" /tmp/nginx.conf
 fi
 
-nginx
+
+nginx -c /tmp/nginx.conf


### PR DESCRIPTION
Changes to allow the final webapp to run as non-root (nginx.conf/startup.sh)

Other changes to allow building with podman. PR in draft until I confirm these changes don't break building with docker. (Some of the image tagging/volume naming seems a little different for podman). Had to add "localhost/" prefix for the local image, "--name" isn't supported in podman for volumes, had to add `:Z` to mounted dir, and use "podman unshare chown" to grant permissions. Can always gate all this based on if we discover docker is podman during the build.. 

Have to use npx gulp, as no permission to install systemwide as non root.

